### PR TITLE
Update VERSION retrieval in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE_NAME=ynput/ayon-ash
-VERSION=$(shell python -c "import ash; print(ash.__version__, end='')")
+VERSION=$(shell python -c "from ash.version import __version__; print(__version__, end='')")
 
 run: build
 	docker run \


### PR DESCRIPTION
Changed VERSION assignment to use the explicit import for the version.py module from ASH package.

## Changelog Description
Previous behaviour was expecting "__version__" to be in __init__.py, which was removed in this [commit](https://github.com/ynput/ash/commit/de35015c1c6c00ff1f72db3f35d7a5f3472fe721)

## Testing notes:
Run 'make run'
