### PR TITLE
Add ports to service

### DIFF
--- a/ash/services.py
+++ b/ash/services.py
@@ -63,7 +63,7 @@ class Services:
             return None
 
         container: Container = cls.client.containers.run(
-            image= image,
+            image=image,
             detach=True,
             auto_remove=True,
             environment=environment,
@@ -156,7 +156,7 @@ class Services:
                     elif len(ports_pair) == 2:
                         # If two ports are specified, the first is the host port
                         # and the second is the container port
-                        ports[ports_pair[1]] = int(ports_pair[0])
+                        ports[ports_pair[0]] = int(ports_pair[1])
 
             container = cls.spawn(
                 image,

--- a/ash/services.py
+++ b/ash/services.py
@@ -54,6 +54,7 @@ class Services:
         environment: dict[str, str],
         labels: dict[str, str],
         volumes: list[str] | None,
+        ports: dict[str, int | None] | None = None,
         **kwargs: Any,
     ) -> Container | None:
         if cls.client is None:
@@ -62,7 +63,7 @@ class Services:
             return None
 
         container: Container = cls.client.containers.run(
-            image,
+            image= image,
             detach=True,
             auto_remove=True,
             environment=environment,
@@ -72,8 +73,8 @@ class Services:
             name=hostname,
             labels=labels,
             volumes=volumes,
-            **kwargs,
-        )
+            ports=ports,
+            **kwargs,)
         return container
 
     @classmethod
@@ -145,12 +146,25 @@ class Services:
                 if target.startswith("/storage"):
                     volumes.append(bind_mount)
 
+            ports: dict[str, int | None] = {}
+            if config.network_mode != "host":
+                for p in service_config.ports or []:
+                    ports_pair = p.split(":")
+                    if len(ports_pair) == 1:
+                        # If only one port is specified, it is the container port
+                        ports[ports_pair[1]] = None
+                    elif len(ports_pair) == 2:
+                        # If two ports are specified, the first is the host port
+                        # and the second is the container port
+                        ports[ports_pair[0]] = int(ports_pair[1])
+
             container = cls.spawn(
                 image,
                 hostname,
                 environment,
                 labels,
                 volumes or None,
+                ports=ports or None,
             )
 
         # Ensure container logger is running

--- a/ash/services.py
+++ b/ash/services.py
@@ -74,7 +74,7 @@ class Services:
             labels=labels,
             volumes=volumes,
             ports=ports,
-            **kwargs,)
+            **kwargs)
         return container
 
     @classmethod
@@ -152,11 +152,11 @@ class Services:
                     ports_pair = p.split(":")
                     if len(ports_pair) == 1:
                         # If only one port is specified, it is the container port
-                        ports[ports_pair[1]] = None
+                        ports[ports_pair[0]] = None
                     elif len(ports_pair) == 2:
                         # If two ports are specified, the first is the host port
                         # and the second is the container port
-                        ports[ports_pair[0]] = int(ports_pair[1])
+                        ports[ports_pair[1]] = int(ports_pair[0])
 
             container = cls.spawn(
                 image,

--- a/ash/services.py
+++ b/ash/services.py
@@ -151,12 +151,17 @@ class Services:
                 for p in service_config.ports or []:
                     ports_pair = p.split(":")
                     if len(ports_pair) == 1:
-                        # If only one port is specified, it is the container port
-                        ports[ports_pair[0]] = None
+                        # Compose-like UX: "8080" means
+                        # host 8080 -> container 8080.
+                        host_port = int(ports_pair[0])
+                        container_port = ports_pair[0]
+                        ports[container_port] = host_port
                     elif len(ports_pair) == 2:
-                        # If two ports are specified, the first is the host port
-                        # and the second is the container port
-                        ports[ports_pair[0]] = int(ports_pair[1])
+                        # Keep UI syntax as host:container and
+                        # translate for Docker SDK {container: host}.
+                        host_port = int(ports_pair[0])
+                        container_port = ports_pair[1]
+                        ports[container_port] = host_port
 
             container = cls.spawn(
                 image,


### PR DESCRIPTION
## Changelog Description
Pass ports definition to spawned service.

## Additional review information
Portsd were not passed to the service. It can be now defined using https://github.com/ynput/ayon-frontend/pull/1328

Closes #14 

## Testing notes:
* Define service with ports (like `[4000:4000]`) 
* Let ash to create and run it